### PR TITLE
Refactored Day/Time of Courses

### DIFF
--- a/src/main/java/Course.java
+++ b/src/main/java/Course.java
@@ -1,6 +1,9 @@
 import java.lang.reflect.Array;
 import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Scanner;
 
 
@@ -14,9 +17,10 @@ public class Course {
     private ArrayList<Course> prereqs;
     private Professor professor;
     private String endDate;
-    private ArrayList<DayOfWeek> days;
-    private ArrayList<String> times;
+//    private ArrayList<DayOfWeek> days;
+//    private ArrayList<String> times;
     // term should always be a String in the format like "S24" or "F22"
+    private HashMap<DayOfWeek,ArrayList<LocalTime>> meetingTimes;
     private String term;
     private ArrayList<String> room;
 
@@ -44,15 +48,19 @@ public class Course {
         return prereqs;
     }
 
-    public ArrayList<DayOfWeek> getDays() {
-        return days;
-    }
+//    public ArrayList<DayOfWeek> getDays() {
+//        return days;
+//    }
     public ArrayList<String> getRoom() {
         return room;
     }
 
-    public ArrayList<String> getTimes() {
-        return times;
+//    public ArrayList<String> getTimes() {
+//        return times;
+//    }
+
+    public HashMap<DayOfWeek, ArrayList<LocalTime>> getMeetingTimes() {
+        return meetingTimes;
     }
 
     public Professor getProfessor() {
@@ -76,8 +84,9 @@ public class Course {
             ArrayList<Course> prereqs,
             Professor professor,
             String endDate,
-            ArrayList<DayOfWeek> days,
-            ArrayList<String> times,
+//            ArrayList<DayOfWeek> days,
+//            ArrayList<String> times,
+            HashMap<DayOfWeek,ArrayList<LocalTime>> meetingTimes,
             String term,
             ArrayList<String> room
     ){
@@ -89,8 +98,9 @@ public class Course {
         this.prereqs = prereqs;
         this.professor = professor;
         this.endDate = endDate;
-        this.days = days;
-        this.times = times;
+//        this.days = days;
+//        this.times = times;
+        this.meetingTimes = meetingTimes;
         this.term = term;
         this.room = room;
     }

--- a/src/main/java/CourseReader.java
+++ b/src/main/java/CourseReader.java
@@ -1,5 +1,8 @@
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
 import java.util.*;
 
 public class CourseReader {
@@ -82,9 +85,26 @@ public class CourseReader {
             trm_cde = "S";
             trm_cde += String.valueOf(yr_cde - 2000 + 1);
         }
-        int credits = 0; // TODO: what value should credits be if none?
+        int credits = 0;
         if (!credit_hrs.equals("")) {
             credits = Integer.parseInt(credit_hrs); //reading str as int
+        }
+
+        HashMap<DayOfWeek, ArrayList<LocalTime>> meetings = new HashMap<>();
+        for (String day : days) {
+            ArrayList<LocalTime> beginAndEnd = new ArrayList<>();
+            beginAndEnd.add(LocalTime.parse(begin_tim, DateTimeFormatter.ISO_LOCAL_TIME)); // reads the String as a time (HH:MM:SS)
+            beginAndEnd.add(LocalTime.parse(end_tim, DateTimeFormatter.ISO_LOCAL_TIME));
+            if (day != null) {
+                switch (day) {
+                    case "M" -> meetings.put(DayOfWeek.MONDAY, beginAndEnd);
+                    case "T" -> meetings.put(DayOfWeek.TUESDAY, beginAndEnd);
+                    case "W" -> meetings.put(DayOfWeek.WEDNESDAY, beginAndEnd);
+                    case "R" -> meetings.put(DayOfWeek.THURSDAY, beginAndEnd);
+                    case "F" -> meetings.put(DayOfWeek.FRIDAY, beginAndEnd);
+                    default -> meetings.put(DayOfWeek.SATURDAY, beginAndEnd); // more of a placeholder than anything
+                }
+            }
         }
 
         // create a new Course from these parameters
@@ -96,10 +116,10 @@ public class CourseReader {
                 null,
                 new Professor(first_name, last_name),
                 null,
-                null,
-                null,
+                meetings,
                 trm_cde,
-                null);
+                null
+            );
         return c;
     }
 


### PR DESCRIPTION
Removed days and times from Course and replaced with `HashMap meetingTimes<DayOfWeek, ArrayList<LocalTime>>`. Also edited CourseReader to reflect these changes.

Also, 0 credits is a good default for a course with no credits specified.

Based on the 2020-2021 database csv, there is only one column for course time of day, so Calculus courses are not yet perfectly represented, since their Tuesday/Thursday (TR) times will be their MWF times.

As-of-yet untested